### PR TITLE
Improve subprocess

### DIFF
--- a/src/main/scala/afenton/bazel/bsp/FilesIO.scala
+++ b/src/main/scala/afenton/bazel/bsp/FilesIO.scala
@@ -20,17 +20,13 @@ object FilesIO:
 
   val cwd: IO[Path] = IO.blocking(Paths.get("").toAbsolutePath.normalize)
 
-  def readLines(file: Path): IO[List[String]] =
-    IO.blocking(Files.readAllLines(file).asScala.toList)
-
   def readBytes(file: Path): IO[Array[Byte]] =
     IO.blocking(Files.readAllBytes(file))
 
   def readJson[T: Decoder](file: Path): IO[T] =
-    readLines(file)
-      .flatMap { lines =>
-        val allLines = lines.mkString("\n")
-        val decoded = io.circe.parser.decode(allLines)
+    readBytes(file)
+      .flatMap { bytes =>
+        val decoded = io.circe.parser.decode(new String(bytes, "utf-8"))
         IO.fromEither(decoded)
       }
 

--- a/src/main/scala/afenton/bazel/bsp/runner/BazelRunner.scala
+++ b/src/main/scala/afenton/bazel/bsp/runner/BazelRunner.scala
@@ -148,10 +148,8 @@ object BazelRunner:
       FilesIO.readJson[BazelSources](filePath).map(_.sources)
 
     def targetSources(target: BazelLabel): IO[List[String]] =
-      runBazel(Command.Build, target)
-        .use { _ =>
-          readSourceFile(target)
-        }
+      runBazel(Command.Build, target).use_ *>
+        readSourceFile(target)
 
     private def diagnostics: Stream[IO, FileDiagnostics] =
       FilesIO

--- a/src/main/scala/afenton/bazel/bsp/runner/BazelRunner.scala
+++ b/src/main/scala/afenton/bazel/bsp/runner/BazelRunner.scala
@@ -122,9 +122,7 @@ object BazelRunner:
     def bspTargets: IO[List[BspServer.Target]] =
       runBazelOk(Command.Query, Some("kind(bsp_target, //...)"))
         .use { er =>
-          for
-            stdout <- er.stdoutLines.compile.toList
-          yield stdout
+          er.stdoutLines
             .map(BazelLabel.fromString)
             .collect { case Right(label) =>
               BspServer.Target(
@@ -132,6 +130,8 @@ object BazelRunner:
                 label.target.map(_.asString).getOrElse(label.asString)
               )
             }
+            .compile
+            .toList
         }
 
     def shutdown: IO[Unit] =

--- a/src/main/scala/afenton/bazel/bsp/runner/SubProcess.scala
+++ b/src/main/scala/afenton/bazel/bsp/runner/SubProcess.scala
@@ -152,10 +152,14 @@ object SubProcess:
       stderrPath: Path
   ) extends ExecutionResult {
     def stdoutLines: Stream[IO, String] =
-      fs2Files[IO].readAll(fs2Path.fromNioPath(stdoutPath)).through(fs2.text.utf8.decode)
+      fs2Files[IO].readAll(fs2Path.fromNioPath(stdoutPath))
+        .through(fs2.text.utf8.decode)
+        .through(fs2.text.lines)
 
     def stderrLines: Stream[IO, String] =
-      fs2Files[IO].readAll(fs2Path.fromNioPath(stderrPath)).through(fs2.text.utf8.decode)
+      fs2Files[IO].readAll(fs2Path.fromNioPath(stderrPath))
+        .through(fs2.text.utf8.decode)
+        .through(fs2.text.lines)
   }
 
   def from(

--- a/src/test/scala/afenton/bazel/bsp/End2EndTest.scala
+++ b/src/test/scala/afenton/bazel/bsp/End2EndTest.scala
@@ -20,7 +20,6 @@ import io.circe.syntax.*
 import java.nio.file.Path
 import java.nio.file.Paths
 import scala.concurrent.duration._
-import scala.reflect.Typeable
 
 class End2EndTest extends munit.CatsEffectSuite with BspHelpers:
 

--- a/src/test/scala/afenton/bazel/bsp/runner/SubProcessTest.scala
+++ b/src/test/scala/afenton/bazel/bsp/runner/SubProcessTest.scala
@@ -22,7 +22,7 @@ class SubProcessTest extends munit.CatsEffectSuite:
 
     assertEquals(ec1, 0)
     assertEquals(errLen1, 0)
-    assertEquals(out1, List("stdout"))
+    assertEquals(out1, List("stdout", ""))
 
     val (ec2, err2) = SubProcess
       .from(Paths.get("/tmp"), "ls", "doesnotexist")


### PR DESCRIPTION
two main ideas here:

1. use Resource for running a subprocess so we can delete the redirected files when we are done (so we don't build them up for a long time if the servers stays resident).
2. use `Stream[IO, String]` instead of `IO[Seq[String]]` which was copied from our internal code that does not (yet) use fs2.