### PR TITLE
More experiments with Option to IO macros

### DIFF
--- a/src/main/scala/afenton/bazel/bsp/BazelBspServer.scala
+++ b/src/main/scala/afenton/bazel/bsp/BazelBspServer.scala
@@ -20,6 +20,8 @@ import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
 
+import IOLifts.{asIO, mapToIO}
+
 class BazelBspServer(
     client: BspClient,
     logger: Logger,
@@ -59,14 +61,15 @@ class BazelBspServer(
     for
       _ <- logger.info("build/initialized")
       state <- stateRef.get
-      root <- IOLifts.fromOption(state.workspaceRoot)
-      runner <- IOLifts.fromOption(state.bazelRunner)
+      root <- state.workspaceRoot.asIO
       ws <- workspaceBuildTargets(())
-      ts <- doBuildTargetSources(
-        root,
-        runner,
-        ws.targets.map(_.id)
-      )
+      ts <- state.bazelRunner.mapToIO { runner =>
+        doBuildTargetSources(
+          root,
+          runner,
+          ws.targets.map(_.id)
+        )
+      }
       _ <- stateRef.update(s => s.copy(targetSourceMap = BazelBspServer.TargetSourceMap(ts)))
     yield ()
 
@@ -76,7 +79,7 @@ class BazelBspServer(
     for
       _ <- logger.info("buildTarget/inverseSources")
       state <- stateRef.get
-      root <- IOLifts.fromOption(state.workspaceRoot)
+      root <- state.workspaceRoot.asIO
     yield
       val relativeUri =
         UriFactory.fileUri(
@@ -118,8 +121,8 @@ class BazelBspServer(
     for
       _ <- logger.info("workspace/buildTargets")
       state <- stateRef.get
-      runner <- IOLifts.fromOption(state.bazelRunner)
-      root <- IOLifts.fromOption(state.workspaceRoot)
+      runner <- state.bazelRunner.asIO
+      root <- state.workspaceRoot.asIO
       bspTargets <- runner.bspTargets
     yield WorkspaceBuildTargetsResult(
       bspTargets.map(t => buildTarget(t, root))
@@ -169,12 +172,11 @@ class BazelBspServer(
             yield ()
           }
           .evalTap { fd =>
-            IOLifts.fromOption(PublishDiagnosticsParams.fromScalacDiagnostic(
+            PublishDiagnosticsParams.fromScalacDiagnostic(
               workspaceRoot,
               target,
               fd
-            ))
-              .flatMap(client.publishDiagnostics(_))
+            ).mapToIO(client.publishDiagnostics(_))
           }
           .compile
           .toList
@@ -189,16 +191,15 @@ class BazelBspServer(
   ): IO[Unit] =
     for
       state <- stateRef.get
-      root <- IOLifts.fromOption(state.workspaceRoot)
+      root <- state.workspaceRoot.asIO
       pathSet = fds.map(fs => fs.path).toSet
       clearDiagnostics <- state.currentErrors
         .filterNot(fd => pathSet.contains(fd.path))
         .map(_.clearDiagnostics)
-        .traverse(fd =>
-          IOLifts.fromOption(
-            PublishDiagnosticsParams
-              .fromScalacDiagnostic(root, target, fd))
-        )
+        .traverse { fd =>
+          PublishDiagnosticsParams
+            .fromScalacDiagnostic(root, target, fd).asIO
+        }
       _ <- clearDiagnostics.traverse_(client.publishDiagnostics)
       _ <- stateRef.update(_.copy(currentErrors = fds))
     yield ()
@@ -217,9 +218,10 @@ class BazelBspServer(
         )
       )
       state <- stateRef.get
-      runner <- IOLifts.fromOption(state.bazelRunner)
-      root <- IOLifts.fromOption(state.workspaceRoot)
-      fds <- doCompile(root, runner, target, id)
+      runner <- state.bazelRunner.asIO
+      fds <- state.workspaceRoot.mapToIO { root =>
+        doCompile(root, runner, target, id)
+      }
       _ <- clearPrevDiagnostics(target, fds)
       end <- IO.realTimeInstant
       _ <- client.buildTaskFinished(
@@ -274,7 +276,7 @@ class BazelBspServer(
     for
       _ <- logger.info("buildTarget/sources")
       state <- stateRef.get
-      root <- IOLifts.fromOption(state.workspaceRoot)
+      root <- state.workspaceRoot.asIO
     yield
       val sourcesItem = params.targets.map { target =>
         val sources = state.targetSourceMap

--- a/src/test/scala/afenton/bazel/bsp/IOLiftsTest.scala
+++ b/src/test/scala/afenton/bazel/bsp/IOLiftsTest.scala
@@ -1,0 +1,70 @@
+package afenton.bazel.bsp
+
+import IOLifts.{fromOption, asIO}
+
+class IOLiftsTest extends munit.CatsEffectSuite {
+  test("fromOption(Some(x))") {
+    fromOption(Some(1)).assertEquals(1)
+  }
+
+  test("fromOption(Option(x))") {
+    fromOption(Option(1)).assertEquals(1)
+  }
+
+  test("fromOption(None)") {
+    fromOption(None)
+      .attempt
+      .map(_.left.map { e =>
+        e.isInstanceOf[java.util.NoSuchElementException] &&
+          e.getMessage.contains("IOLiftsTest.scala") &&
+          e.getMessage.contains("line: 15")
+      })
+      .assertEquals(Left(true))
+  }
+
+  test("fromOption(Option(null))") {
+    fromOption(Option(null))
+      .attempt
+      .map(_.left.map { e =>
+        e.isInstanceOf[java.util.NoSuchElementException] &&
+          e.getMessage.contains("IOLiftsTest.scala") &&
+          e.getMessage.contains("line: 26")
+      })
+      .assertEquals(Left(true))
+  }
+
+  test("{ val x = Some(1); fromOption(x) }") {
+    { val x = Some(1); fromOption(x) }
+      .assertEquals(1)
+  }
+
+  test("{ val x: Option[Int] = None; fromOption(x) }") {
+      { val x: Option[Int] = None; fromOption(x) }
+      .attempt
+      .map(_.left.map { e =>
+        e.isInstanceOf[java.util.NoSuchElementException] &&
+          e.getMessage.contains("IOLiftsTest.scala") &&
+          e.getMessage.contains("line: 42")
+      })
+      .assertEquals(Left(true))
+  }
+
+  test("Some(x).asIO") {
+    Some(1).asIO.assertEquals(1)
+  }
+
+  test("Option(x).asIO") {
+    Option(1).asIO.assertEquals(1)
+  }
+
+  test("None.asIO") {
+    None.asIO
+      .attempt
+      .map(_.left.map { e =>
+        e.isInstanceOf[java.util.NoSuchElementException] &&
+          e.getMessage.contains("IOLiftsTest.scala") &&
+          e.getMessage.contains("line: 61")
+      })
+      .assertEquals(Left(true))
+  }
+}


### PR DESCRIPTION
I'm sorry for geeking out about this, but I'm interested in learning what can be done.

I realized you often want to flatMap the `IO[A]` you get, but you could do that by directly applying the flatMap function instead of doing `IO.pure(a).flatMap(fn)` and instead inline directly to `fn(a)` when the option is defined.

